### PR TITLE
Disambiguate process name

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: uvicorn src.sse_server:app --host=0.0.0.0 --port=${PORT:-8000} --workers=${WEB_CONCURRENCY:-1}
-mcp: python -m src.stdio_server
+mcp-doc-reader: python -m src.stdio_server


### PR DESCRIPTION
Using the `mcp` process name across multiple apps sharing the same addon causes issues. We should use something more specific to keep from conflicting with other apps that might want to use `mcp` (like our other MCP Servers).

[GUS](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002EP9xlYAD/view)