### PR TITLE
fix(tests): replace example.com with w3.org for reliable CI (W-22013135)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 mcp[client,server]==1.26.0
-fastapi==0.128.5
-uvicorn==0.38.0
-python-dotenv==1.2.1
+fastapi==0.135.3
+uvicorn==0.43.0
+python-dotenv==1.2.2
 mando==0.8.2
-requests==2.32.5
+requests==2.33.1
 markdownify==1.2.2
 pdfplumber==0.11.9
 # --- dev / CI only -------------------------------------------------

--- a/src/docread.py
+++ b/src/docread.py
@@ -5,9 +5,11 @@ import tempfile
 import pdfplumber
 from markdownify import markdownify as md
 
+_HEADERS = {"User-Agent": "Mozilla/5.0 (compatible; mcp-doc-reader/1.0)"}
+
 def html_to_markdown(url: str) -> str:
     """Fetch a webpage and convert it to Markdown."""
-    response = requests.get(url)
+    response = requests.get(url, headers=_HEADERS, timeout=30)
     response.raise_for_status()
     html = response.text
     return md(html)
@@ -41,7 +43,7 @@ def pdf_to_markdown(url: str) -> str:
     output = []
 
     with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as tmp_pdf:
-        response = requests.get(url)
+        response = requests.get(url, headers=_HEADERS, timeout=30)
         response.raise_for_status()
         tmp_pdf.write(response.content)
         tmp_pdf_path = tmp_pdf.name

--- a/tests/test_mcp_e2e.py
+++ b/tests/test_mcp_e2e.py
@@ -57,10 +57,10 @@ async def test_list_tools(ctx):
 async def test_html_to_markdown(ctx):
     payload = json.dumps({
         "name": "html_to_markdown",
-        "arguments": {"url": "https://example.com"}
+        "arguments": {"url": "https://www.w3.org/"}
     })
     data = await _safe_call(ctx, "call_tool", "--args", payload)
-    assert "This domain is for use in documentation examples without needing permission" in data
+    assert "World Wide Web Consortium" in data
 
 
 async def test_pdf_to_markdown(ctx):


### PR DESCRIPTION
## Root Cause

`test_html_to_markdown` has been failing on all Dependabot PRs since ~Feb 16, 2026. The failure was **not caused by any dependency bump** — it was a coincidence in timing.

**What actually happened:** IANA moved `example.com` to Cloudflare around Feb 9–16, 2026 with strict bot protection enabled. Cloudflare blocks requests from known cloud-provider IP ranges (Azure = GitHub Actions) when the `python-requests` User-Agent is used. W3C (used by the existing `pdf_to_markdown` test) is also Cloudflare but with less strict settings, which is why that test kept passing.

**Evidence:**
- Last green CI: Feb 9, 2026 (fastapi 0.128.5, Azure `westus`)
- First red CI: Feb 16, 2026 (fastapi 0.129.0, Azure `northcentralus`) — fastapi version is a red herring
- `pdf_to_markdown` test with `w3.org` continues to pass throughout — same `requests.get()` pattern
- `example.com` response headers: `server: cloudflare` with `last-modified: Fri, 10 Apr 2026`

## Changes

- `tests/test_mcp_e2e.py`: swap `example.com` → `www.w3.org/` (proven reliable from GitHub Actions); update assertion to `"World Wide Web Consortium"`
- `src/docread.py`: add `User-Agent` and `timeout=30` to both `requests.get()` calls — improves production robustness and reduces bot-detection false positives for real users
- `requirements.txt`: consolidates all pending Dependabot bumps — fastapi 0.135.3, uvicorn 0.43.0, python-dotenv 1.2.2, requests 2.33.1 (closes #78, #81, #83, #84, #85)

## Test plan
- [x] CI passes on this PR (all 3 local transport variants of `test_html_to_markdown`)
- [ ] Merge and confirm Dependabot PRs #78 #81 #83 #84 #85 are closed

## Context

GUS: https://gus.my.salesforce.com/a07EE00002Y1vZvYAJ